### PR TITLE
Chore/issue 8 ingestion bugs

### DIFF
--- a/src/ai_knowledge_assistant/cli.py
+++ b/src/ai_knowledge_assistant/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 import ai_knowledge_assistant.config as config
@@ -40,6 +41,8 @@ def cmd_index(args: argparse.Namespace) -> int:
         return EXIT_USAGE_ERROR
 
     chunks: list[Chunk] = get_chunks_from_files(text_by_file)
+
+    os.makedirs(os.path.dirname(config.INDEX_FILE), exist_ok=True)
     save_chunks(chunks, path=config.INDEX_FILE)
     logger.info("Saved %d chunks to index.", len(chunks))
 

--- a/src/ai_knowledge_assistant/embedding/builder.py
+++ b/src/ai_knowledge_assistant/embedding/builder.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING
-
-from sentence_transformers import SentenceTransformer
+from typing import TYPE_CHECKING, Any, cast
 
 from .base import EmbeddedChunk, EmbeddingConfig
 
 if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
+
     from ai_knowledge_assistant.normalize.base import Chunk
+
+
+def _load_sentence_transformer() -> type[SentenceTransformer]:
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer
 
 
 class EmbeddingBuilder:
@@ -31,7 +37,9 @@ class EmbeddingBuilder:
         if self._model is None:
             os.environ["TQDM_DISABLE"] = "1"
             logging.getLogger("transformers").setLevel(logging.ERROR)
-            self._model = SentenceTransformer(self._config.model_name)
+            sentence_transformer_cls:type[SentenceTransformer] = _load_sentence_transformer()
+            self._model = sentence_transformer_cls(self._config.model_name)
+        assert self._model is not None
         return self._model
 
     def build_vectors(self, chunks: list[Chunk]) -> list[EmbeddedChunk]:

--- a/src/ai_knowledge_assistant/embedding/builder.py
+++ b/src/ai_knowledge_assistant/embedding/builder.py
@@ -37,7 +37,9 @@ class EmbeddingBuilder:
         if self._model is None:
             os.environ["TQDM_DISABLE"] = "1"
             logging.getLogger("transformers").setLevel(logging.ERROR)
-            sentence_transformer_cls:type[SentenceTransformer] = _load_sentence_transformer()
+            sentence_transformer_cls: type[SentenceTransformer] = (
+                _load_sentence_transformer()
+            )
             self._model = sentence_transformer_cls(self._config.model_name)
         assert self._model is not None
         return self._model

--- a/src/ai_knowledge_assistant/grounding/answerability.py
+++ b/src/ai_knowledge_assistant/grounding/answerability.py
@@ -6,7 +6,6 @@ from ai_knowledge_assistant.normalize.chunker import Chunk
 
 
 class AnswerabilityGate:
-
     def __init__(self, min_chars: int = MIN_TOTAL_CHARS):
         self._min_chars = min_chars
 

--- a/src/ai_knowledge_assistant/grounding/output_validator.py
+++ b/src/ai_knowledge_assistant/grounding/output_validator.py
@@ -7,7 +7,6 @@ from ai_knowledge_assistant.normalize.chunker import Chunk
 
 
 class OutputValidator:
-
     def __init__(self, pattern: str = CITATION_PATTERN):
         self._pattern = pattern
 

--- a/src/ai_knowledge_assistant/ingest/reader.py
+++ b/src/ai_knowledge_assistant/ingest/reader.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from pathlib import Path
 
 from ai_knowledge_assistant.config import SUPPORTED_EXTENSIONS
 
@@ -57,7 +58,7 @@ def read_file(file_path: str) -> str | None:
         logger.error(f"Path {file_path} - Isn't file")
         return None
 
-    suffix = file_path.split(".")[-1]
+    suffix = Path(file_path).suffix.lstrip(".")
 
     if suffix in SUPPORTED_EXTENSIONS:
         with open(file_path, errors="ignore") as f:

--- a/src/ai_knowledge_assistant/ingest/reader.py
+++ b/src/ai_knowledge_assistant/ingest/reader.py
@@ -24,7 +24,7 @@ def read_files(paths: list[str]) -> dict[str, str]:
 
 def explore_files(paths: list[str]) -> list[str]:
 
-    file_paths = []
+    file_paths: set[str] = set()
 
     for cur_path in paths:
         abs_path = os.path.abspath(cur_path)
@@ -34,19 +34,17 @@ def explore_files(paths: list[str]) -> list[str]:
 
         logger.debug(f"{abs_path:<80}: Exist")
         if os.path.isfile(abs_path):
-            file_paths.append(abs_path)
+            file_paths.add(abs_path)
 
         elif os.path.isdir(abs_path):
-            files_list = os.listdir(abs_path)
-            full_paths = [os.path.join(abs_path, file) for file in files_list]
+            for dirpath, _, filenames in os.walk(abs_path):
+                logger.debug(f"{dirpath=}")
+                logger.debug(f"{filenames=}")
+                for filename in filenames:
+                    full_path = os.path.join(dirpath, filename)
+                    file_paths.add(full_path)
 
-            logger.debug(f"{abs_path=}")
-            logger.debug(f"{files_list=}")
-            logger.debug(f"{list(zip(files_list, full_paths, strict=True))}")
-
-            file_paths.extend(explore_files(full_paths))
-
-    return file_paths
+    return sorted(file_paths)
 
 
 def read_file(file_path: str) -> str | None:

--- a/src/ai_knowledge_assistant/ingest/reader.py
+++ b/src/ai_knowledge_assistant/ingest/reader.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def read_files(paths: list[str]) -> dict[str, str]:
     logger.debug(f"read_files({paths})")
     file_paths = explore_files(paths)
-    logger.info(f'file_paths: [\n\t{"\n\t".join(file_paths)}\n\t]')
+    logger.info(f"file_paths: [\n\t{'\n\t'.join(file_paths)}\n\t]")
 
     files_content = {}
     for file_path in file_paths:

--- a/src/ai_knowledge_assistant/llm/openai_client.py
+++ b/src/ai_knowledge_assistant/llm/openai_client.py
@@ -8,7 +8,6 @@ from ai_knowledge_assistant.llm.base import LLMClient, LLMConfig
 
 
 class OpenAIClient(LLMClient):
-
     def __init__(
         self, api_key: str | None = None, default_model: str = DEFAULT_LLM_MODEL
     ):

--- a/src/ai_knowledge_assistant/retrieve/retriever.py
+++ b/src/ai_knowledge_assistant/retrieve/retriever.py
@@ -2,7 +2,11 @@
 
 import logging
 
-from ai_knowledge_assistant.embedding import EmbeddingConfig, EmbeddedChunk, EmbeddingBuilder
+from ai_knowledge_assistant.embedding import (
+    EmbeddingConfig,
+    EmbeddedChunk,
+    EmbeddingBuilder,
+)
 from ai_knowledge_assistant.normalize import Chunk
 from ai_knowledge_assistant.store import FaissStore, ScoredChunk, load_chunks_vectors
 

--- a/src/ai_knowledge_assistant/store/base.py
+++ b/src/ai_knowledge_assistant/store/base.py
@@ -38,7 +38,6 @@ def load_from_json[T](path: str, cls: type[T], label: str = "items") -> list[T]:
 
 @dataclass(frozen=True)
 class ScoredChunk:
-
     source: str
     index: int
     text: str

--- a/src/ai_knowledge_assistant/store/faiss_store.py
+++ b/src/ai_knowledge_assistant/store/faiss_store.py
@@ -38,7 +38,6 @@ class FaissStore:
         faiss.normalize_L2(q)
         scores, indices = self.index.search(q, k)  # type: ignore[call-arg]
         for score, indic in zip(scores[0], indices[0], strict=True):
-
             if indic == -1:
                 continue
             if score < threshold:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+from unittest.mock import MagicMock, patch
+
+from ai_knowledge_assistant.cli import cmd_index
+
+
+@patch("ai_knowledge_assistant.cli.save_chunks_vectors")
+@patch("ai_knowledge_assistant.cli.EmbeddingBuilder")
+@patch("ai_knowledge_assistant.cli.save_chunks")
+@patch("ai_knowledge_assistant.cli.get_chunks_from_files", return_value=[MagicMock()])
+@patch("ai_knowledge_assistant.cli.read_files", return_value={"f.txt": "hello"})
+def test_cmd_index_creates_output_dir(
+    mock_read, mock_chunks, mock_save, mock_emb_cls, mock_save_vec, tmp_path
+):
+    """Issue #9: cmd_index must create the output directory before saving."""
+    index_file = str(tmp_path / "sub" / "index.json")
+    vectors_file = str(tmp_path / "sub" / "vectors.json")
+
+    mock_emb_instance = MagicMock()
+    mock_emb_instance.build_vectors.return_value = []
+    mock_emb_cls.return_value = mock_emb_instance
+
+    args = argparse.Namespace(paths=["some/path"])
+
+    with patch("ai_knowledge_assistant.cli.config") as mock_config:
+        mock_config.INDEX_FILE = index_file
+        mock_config.VECTORS_FILE = vectors_file
+        mock_config.DEFAULT_EMBEDDING = MagicMock()
+
+        result = cmd_index(args)
+
+    assert result == 0
+    assert os.path.isdir(str(tmp_path / "sub"))

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -1,6 +1,6 @@
 import os
 
-from ai_knowledge_assistant.ingest.reader import explore_files
+from ai_knowledge_assistant.ingest.reader import explore_files, read_file
 
 
 def test_explore_files_single_path(tmp_path):
@@ -26,3 +26,21 @@ def test_explore_files_single_path(tmp_path):
 def test_explore_files_non_existent():
     result = explore_files(["/non/existent/path/at/all"])
     assert result == []
+
+
+def test_read_file_supported_extension(tmp_path):
+    f = tmp_path / "hello.txt"
+    f.write_text("some content")
+    assert read_file(str(f)) == "some content"
+
+
+def test_read_file_no_extension(tmp_path):
+    f = tmp_path / "noext"
+    f.write_text("data")
+    assert read_file(str(f)) is None
+
+
+def test_read_file_unsupported_extension(tmp_path):
+    f = tmp_path / "image.png"
+    f.write_bytes(b"\x89PNG")
+    assert read_file(str(f)) is None


### PR DESCRIPTION
Closes #8, closes #9, closes #10, closes #11

- Path Safety: cmd_index creates output directory before saving
- Recursion Fix: replaced recursion with os.walk() + set dedup
- Suffix Parsing: using pathlib.Path.suffix instead of split