### PR TITLE
fix: enforce Liskov principle and standardize type hints

### DIFF
--- a/src/ai_knowledge_assistant/grounding/output_validator.py
+++ b/src/ai_knowledge_assistant/grounding/output_validator.py
@@ -16,13 +16,13 @@ class OutputValidator:
         in the provided context chunks.
         """
         matches = re.findall(self._pattern, answer)
-        matches_set: set = set(matches)
+        matches_set: set[tuple[str, str]] = set(matches)
 
         if not matches_set:
             return False
 
         # Build a set of valid (filename, index) pairs from retrieved contexts
-        contexts_set: set = set(
+        contexts_set: set[tuple[str, str]] = set(
             [
                 (os.path.basename(context.source), str(context.index))
                 for context in contexts

--- a/src/ai_knowledge_assistant/llm/openai_client.py
+++ b/src/ai_knowledge_assistant/llm/openai_client.py
@@ -15,7 +15,7 @@ class OpenAIClient(LLMClient):
         self._client = OpenAI(api_key=api_key)
         self._default_model: str = default_model
 
-    def generate(self, prompt: str, *, config: LLMConfig | None) -> str:
+    def generate(self, prompt: str, *, config: LLMConfig | None = None) -> str:
 
         cfg = config or LLMConfig(model=self._default_model)
 

--- a/src/ai_knowledge_assistant/store/base.py
+++ b/src/ai_knowledge_assistant/store/base.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 logger = logging.getLogger(__name__)
 
 
-def save_to_json(items: list, path: str, label: str = "items") -> None:
+def save_to_json[T](items: list[T], path: str, label: str = "items") -> None:
     """Serializes a list of dataclasses to a JSON file."""
     try:
         items_as_dicts = [asdict(item) for item in items]

--- a/src/ai_knowledge_assistant/store/faiss_store.py
+++ b/src/ai_knowledge_assistant/store/faiss_store.py
@@ -28,10 +28,10 @@ class FaissStore:
         vectors = np.array([c.vector for c in chunks]).astype("float32")
         faiss.normalize_L2(vectors)  # cosine similarity
         self.index.add(vectors)  # type: ignore[call-arg]
-        self.items: list[EmbeddedChunk] = chunks
+        self.items = chunks
 
     def search(
-        self, query_vector: list[float], k: int = 5, threshold=0.3
+        self, query_vector: list[float], k: int = 5, threshold: float = 0.3
     ) -> list[ScoredChunk]:
         results: list[ScoredChunk] = []
         q = np.array([query_vector]).astype("float32")


### PR DESCRIPTION
## Summary

Enforce type safety and SOLID principles across the codebase.

### Changes

- **Liskov fix (closes #13):** Added `= None` default to `OpenAIClient.generate(config=...)` to match base class `LLMClient` signature.
- **Type consistency (closes #14):**
  - `output_validator.py` — `set` → `set[tuple[str, str]]`
  - `faiss_store.py` — removed duplicate `self.items` type annotation, added `threshold: float`
  - `base.py` — `save_to_json` now uses generic `[T]` matching `load_from_json[T]`

Closes #12, closes #13, closes #14