### PR TITLE
docs: add docstrings, README, and RAG demo notebook (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 A CLI-first Retrieval-Augmented Generation (RAG) pipeline for indexing local text files and answering questions with grounded, source-cited responses.
 
-## How It Works
+## Architecture Overview
+
+The system is a single pipeline that transforms raw files into grounded, source-cited answers:
 
 ```text
 Files → Text → Chunks → Embeddings → Vector Store → Retrieval → Answer + Source
 ```
 
-| Stage             | Module                      | Description                                       |
-| ----------------- | --------------------------- | ------------------------------------------------- |
-| **Ingestion**     | `ingest/reader.py`      | Reads `.txt` and `.md` files recursively          |
-| **Normalization** | `normalize/chunker.py`  | Splits text into overlapping chunks               |
-| **Embedding**     | `embedding/builder.py`  | Generates vectors via `sentence-transformers`     |
-| **Storage**       | `store/`                | Persists chunks (JSON) and vectors (JSON + FAISS) |
-| **Retrieval**     | `retrieve/retriever.py` | Semantic search over FAISS index                  |
-| **Reasoning**     | `rag/prompt_builder.py` | Builds a grounded prompt with context             |
-| **LLM**           | `llm/openai_client.py`  | Calls OpenAI to generate an answer                |
-| **Grounding**     | `grounding/`            | Gates on context quality and validates citations  |
+| Stage             | Module                 | Description                                          |
+| ----------------- | ---------------------- | ---------------------------------------------------- |
+| **Ingestion**     | `ingest/reader.py`     | Reads `.txt` and `.md` files recursively             |
+| **Normalization** | `normalize/chunker.py` | Splits text into overlapping fixed-size chunks       |
+| **Embedding**     | `embedding/builder.py` | Generates vectors via `sentence-transformers`        |
+| **Storage**       | `store/`               | Persists chunks (JSON) and vectors (JSON + FAISS)    |
+| **Retrieval**     | `retrieve/retriever.py`| Semantic search over FAISS index (cosine similarity) |
+| **Reasoning**     | `rag/prompt_builder.py`| Builds a grounded prompt with context and citations  |
+| **LLM**           | `llm/openai_client.py` | Calls OpenAI to generate an answer                   |
+| **Grounding**     | `grounding/`           | Gates on context quality and validates citations     |
 
 ## Prerequisites
 
@@ -53,7 +55,7 @@ pip install -r requirements.txt
 
 ## Configuration
 
-Set your OpenAI API key before running any `index` and `ask` command:
+Set your OpenAI API key before running any `index` or `ask` command:
 
 ```powershell
 # PowerShell
@@ -65,95 +67,137 @@ $env:OPENAI_API_KEY = "sk-..."
 export OPENAI_API_KEY="sk-..."
 ```
 
-## Quick Start
+## Usage
 
-**1. Index your documents:**
+### 1. Index your documents
+
+Scan files and directories, build chunks and embeddings, and write the index:
 
 ```bash
 python -m ai_knowledge_assistant.cli index data_set/inputs
 ```
 
-**2. Ask a question:**
+This produces two output files:
+
+- `data_set/output/index.json` -- chunk metadata
+- `data_set/output/vectors.json` -- embedding vectors
+
+You can pass multiple paths:
+
+```bash
+python -m ai_knowledge_assistant.cli index path/to/docs path/to/notes
+```
+
+### 2. Ask a question
+
+Query the indexed knowledge and receive a grounded answer with source citations:
 
 ```bash
 python -m ai_knowledge_assistant.cli ask "What are the main topics in the indexed files?"
+```
+
+Customize the query with options:
+
+```bash
+python -m ai_knowledge_assistant.cli ask "Explain how FAISS indexing works" \
+  --limit 10 --model gpt-4.1 --temperature 0.1 --max-tokens 800
 ```
 
 ## CLI Reference
 
 ### `index`
 
-Scans files and directories, builds chunks + embeddings, and writes:
-
-- `data_set/output/index.json` — chunk metadata
-- `data_set/output/vectors.json` — embedding vectors
-
 ```bash
 python -m ai_knowledge_assistant.cli index <path1> [path2 ...]
 ```
 
-### `ask`
+Recursively reads supported files (`.txt`, `.md`), splits them into chunks, generates embeddings, and persists everything to `data_set/output/`.
 
-Queries the indexed knowledge and returns a grounded answer with source citations.
+### `ask`
 
 ```bash
 python -m ai_knowledge_assistant.cli ask "<question>" [options]
 ```
 
-| Option          | Default   | Description                    |
-| --------------- | --------- | ------------------------------ |
-| `--limit`       | `5`       | Max context chunks to retrieve |
-| `--model`       | `gpt-4.1` | OpenAI model name              |
-| `--temperature` | `0.2`     | Sampling temperature (0.0–2.0) |
-| `--max-tokens`  | `600`     | Max output tokens              |
-| `-v, --verbose` | off       | Enable debug logging           |
+| Option          | Default    | Description                    |
+| --------------- | ---------- | ------------------------------ |
+| `--limit`       | `5`        | Max context chunks to retrieve |
+| `--model`       | `gpt-4.1`  | OpenAI model name              |
+| `--temperature` | `0.2`      | Sampling temperature (0.0-2.0) |
+| `--max-tokens`  | `600`      | Max output tokens              |
+| `-v, --verbose` | off        | Enable debug logging           |
 
 ### Global Flags
 
-| Flag            | Description                                           |
-| --------------- | ----------------------------------------------------- |
-| `-v, --verbose` | Print debug-level logs (`MODULE \| LEVEL \| MESSAGE`) |
+| Flag            | Description                                             |
+| --------------- | ------------------------------------------------------- |
+| `-v, --verbose` | Print debug-level logs (`MODULE \| LEVEL \| MESSAGE`)   |
+
+## How Grounding Works
+
+The grounding layer prevents hallucinated or unsupported answers through two checks:
+
+**1. Answerability gate (pre-answer)**
+
+Before calling the LLM, the `AnswerabilityGate` checks whether the retrieved context chunks contain enough content to form a meaningful answer. If the total text length falls below a minimum threshold (800 characters by default), the pipeline returns `INSUFFICIENT_CONTEXT` and exits with code 2.
+
+**2. Citation validation (post-answer)**
+
+After the LLM generates a response, the `OutputValidator` extracts all `[Source: <filename>, chunk <index>]` citations from the answer and verifies that every cited source exists in the retrieved context. If any citation references a chunk that was not retrieved -- or if the answer contains no citations at all -- the pipeline returns `WRONG_CONTEXT` and exits with code 3.
 
 ## Project Structure
 
 ```text
 src/
-└── ai_knowledge_assistant/     # Main Python package
+└── ai_knowledge_assistant/
     ├── __init__.py
-    ├── cli.py                  # Entry point & argument parsing
+    ├── cli.py                  # Entry point and argument parsing
+    ├── config.py               # Centralized constants and defaults
     ├── ingest/
-    │   ├── __init__.py
-    │   └── reader.py           # Recursive file reading
+    │   └── reader.py           # Recursive file reading (.txt, .md)
     ├── normalize/
-    │   ├── __init__.py
-    │   └── chunker.py          # Text → overlapping chunks
+    │   └── chunker.py          # Text → overlapping fixed-size chunks
     ├── embedding/
-    │   ├── __init__.py
-    │   └── builder.py          # Chunks → vector embeddings
+    │   └── builder.py          # Chunks → vector embeddings (sentence-transformers)
     ├── store/
-    │   ├── __init__.py
+    │   ├── base.py             # Shared persistence utilities
     │   ├── json_store.py       # JSON persistence for chunks
     │   ├── vector_store.py     # JSON persistence for vectors
-    │   └── faiss_store.py      # FAISS index & cosine search
+    │   └── faiss_store.py      # FAISS index with cosine similarity search
     ├── retrieve/
-    │   ├── __init__.py
     │   └── retriever.py        # Semantic retrieval pipeline
     ├── rag/
-    │   ├── __init__.py
-    │   └── prompt_builder.py   # Context → grounded prompt
+    │   └── prompt_builder.py   # Context → grounded prompt with citations
     ├── llm/
-    │   ├── __init__.py
-    │   ├── base.py             # LLM client interface
+    │   ├── base.py             # Abstract LLM client interface
     │   └── openai_client.py    # OpenAI implementation
     └── grounding/
-        ├── __init__.py
         ├── answerability.py    # Pre-answer context gate
         └── output_validator.py # Post-answer citation check
+tests/
+├── unit/                       # Unit tests
+└── integration/                # Integration tests
 data_set/
-├── inputs/                     # Source documents (.txt, .md)
-└── output/                     # Generated index & vectors
-pyproject.toml
-requirements.txt
+├── inputs/                     # Source documents
+└── output/                     # Generated index and vectors
+```
+
+## Running Tests
+
+```bash
+pytest
+```
+
+Run with verbose output:
+
+```bash
+pytest -v
+```
+
+Run a specific test file:
+
+```bash
+pytest tests/unit/test_chunker.py
 ```
 
 ## Exit Codes
@@ -162,8 +206,8 @@ requirements.txt
 | ---- | --------------------------------------------------------------- |
 | `0`  | Success                                                         |
 | `1`  | Usage error (no readable files, bad arguments)                  |
-| `2`  | `INSUFFICIENT_CONTEXT` — not enough relevant context found      |
-| `3`  | `WRONG_CONTEXT` — answer citations don't match retrieved chunks |
+| `2`  | `INSUFFICIENT_CONTEXT` -- not enough relevant context found     |
+| `3`  | `WRONG_CONTEXT` -- answer citations don't match retrieved chunks|
 | `4`  | LLM error (API failure, empty response)                         |
 
 ## Troubleshooting
@@ -171,7 +215,7 @@ requirements.txt
 | Problem                    | Solution                                                    |
 | -------------------------- | ----------------------------------------------------------- |
 | `INSUFFICIENT_CONTEXT`     | Index more documents or increase `--limit`                  |
-| `WRONG_CONTEXT`            | The LLM hallucinated sources — try lowering `--temperature` |
+| `WRONG_CONTEXT`            | The LLM hallucinated sources -- try lowering `--temperature`|
 | Empty OpenAI response      | Verify `OPENAI_API_KEY` is set and the model name is valid  |
 | `FileNotFoundError` on ask | Run `index` first to generate the vector store              |
 | `ModuleNotFoundError`      | Run from the project root directory                         |
@@ -184,12 +228,6 @@ requirements.txt
 | `sentence-transformers` | Local embedding model            |
 | `faiss-cpu`             | Vector similarity search         |
 | `numpy`                 | Numerical operations for vectors |
-
-## Limitations
-
-- Ingestion supports only `.txt` and `.md` files (no PDF).
-- `data_set/output/` must exist before indexing.
-- All commands must be run from the project root directory.
 
 ## License
 

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,0 +1,508 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "98792343",
+   "metadata": {},
+   "source": [
+    "# AI Knowledge Assistant — RAG Demo\n",
+    "\n",
+    "This notebook demonstrates the **end-to-end Retrieval-Augmented Generation (RAG)** pipeline\n",
+    "of the `ai_knowledge_assistant` project.\n",
+    "\n",
+    "### Pipeline Overview\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "    A[\"📁 Raw Files\"] --> B[\"📖 Ingestion\"]\n",
+    "    B --> C[\"✂️ Chunking\"]\n",
+    "    C --> D[\"🔢 Embedding\"]\n",
+    "    D --> E[\"💾 Storage\"]\n",
+    "    E --> F[\"🔍 Retrieval\"]\n",
+    "    F --> G[\"🚦 Grounding Gate\"]\n",
+    "    G --> H[\"🤖 LLM Generation\"]\n",
+    "    H --> I[\"✅ Citation Validation\"]\n",
+    "    I --> J[\"📝 Grounded Answer\"]\n",
+    "```\n",
+    "\n",
+    "**Sections 1–6** run locally (no API key needed).  \n",
+    "**Sections 7–8** require an `OPENAI_API_KEY` environment variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ff929b6",
+   "metadata": {},
+   "source": [
+    "## 1. Setup & Configuration\n",
+    "\n",
+    "Import all pipeline modules and display the active configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fc7499a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Configuration ===\n",
+      "Embedding model : all-MiniLM-L6-v2\n",
+      "Embedding dim   : 384\n",
+      "Chunk size      : 500\n",
+      "Chunk overlap   : 100\n",
+      "Min total chars : 800\n",
+      "LLM model       : gpt-4.1\n",
+      "Index file      : data_set\\output\\index.json\n",
+      "Vectors file    : data_set\\output\\vectors.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, sys\n",
+    "\n",
+    "# Ensure the src directory is on the path\n",
+    "src_dir = os.path.join(os.getcwd(), \"src\")\n",
+    "if src_dir not in sys.path:\n",
+    "    sys.path.insert(0, src_dir)\n",
+    "\n",
+    "import ai_knowledge_assistant.config as config\n",
+    "from ai_knowledge_assistant.ingest import read_files\n",
+    "from ai_knowledge_assistant.normalize import Chunk, get_chunks_from_files\n",
+    "from ai_knowledge_assistant.embedding import EmbeddingBuilder, EmbeddingConfig, EmbeddedChunk\n",
+    "from ai_knowledge_assistant.store import save_chunks, save_chunks_vectors, FaissStore\n",
+    "from ai_knowledge_assistant.retrieve import Retriever\n",
+    "from ai_knowledge_assistant.grounding import AnswerabilityGate, OutputValidator\n",
+    "from ai_knowledge_assistant.rag import build_prompt\n",
+    "from ai_knowledge_assistant.llm import LLMConfig, OpenAIClient\n",
+    "\n",
+    "print(\"=== Configuration ===\")\n",
+    "print(f\"Embedding model : {config.DEFAULT_EMBEDDING.model_name}\")\n",
+    "print(f\"Embedding dim   : {config.DEFAULT_EMBEDDING.dimension}\")\n",
+    "print(f\"Chunk size      : {config.CHUNK_SIZE}\")\n",
+    "print(f\"Chunk overlap   : {config.CHUNK_OVERLAP}\")\n",
+    "print(f\"Min total chars : {config.MIN_TOTAL_CHARS}\")\n",
+    "print(f\"LLM model       : {config.DEFAULT_LLM_MODEL}\")\n",
+    "print(f\"Index file      : {config.INDEX_FILE}\")\n",
+    "print(f\"Vectors file    : {config.VECTORS_FILE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d633300c",
+   "metadata": {},
+   "source": [
+    "## 2. Ingestion — Reading Files\n",
+    "\n",
+    "The `read_files` function recursively discovers `.txt` and `.md` files\n",
+    "and returns their content as a `dict[str, str]` mapping file path → text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e8b0195a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files discovered: 9\n",
+      "Total characters: 36,928\n",
+      "\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\a.txt  (1,679 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\b.txt  (1,638 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\c.txt  (17,410 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\ai_and_ml_overview.txt  (743 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\cooking_pasta.txt  (208 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\database_and_Storage.txt  (715 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\python_systems.txt  (780 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\t1\\d.txt  (7,166 chars)\n",
+      "  c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\t1\\e.txt  (6,589 chars)\n"
+     ]
+    }
+   ],
+   "source": [
+    "INPUT_DIR = os.path.join(\"data_set\", \"inputs\")\n",
+    "\n",
+    "text_by_file = read_files([INPUT_DIR])\n",
+    "\n",
+    "print(f\"Files discovered: {len(text_by_file)}\")\n",
+    "print(f\"Total characters: {sum(len(t) for t in text_by_file.values()):,}\")\n",
+    "print()\n",
+    "for path, content in text_by_file.items():\n",
+    "    print(f\"  {path}  ({len(content):,} chars)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba077c83",
+   "metadata": {},
+   "source": [
+    "## 3. Chunking — Splitting Text into Overlapping Chunks\n",
+    "\n",
+    "Text is split into fixed-size chunks with overlap to preserve context\n",
+    "across chunk boundaries.  \n",
+    "Default: **500 chars** per chunk, **100 chars** overlap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0a6d2aad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total chunks: 96\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\a.txt, chunk 0] \"Cats are fascinating and beloved companions known for their independent and graceful nature. These domesticated felines ...\"\n",
+      "    Length: 500 chars\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\a.txt, chunk 1] \"hough some breeds can be larger. Their eyes are adapted for excellent night vision, and their hearing is exceptionally a...\"\n",
+      "    Length: 500 chars\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\a.txt, chunk 2] \"ous vocalizations including meowing, purring, and hissing, as well as through body language and scent marking.  Breeds a...\"\n",
+      "    Length: 500 chars\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "chunks = get_chunks_from_files(text_by_file)\n",
+    "\n",
+    "print(f\"Total chunks: {len(chunks)}\")\n",
+    "print()\n",
+    "\n",
+    "# Show the first 3 chunks as examples\n",
+    "for chunk in chunks[:3]:\n",
+    "    preview = chunk.text[:120].replace(\"\\n\", \" \")\n",
+    "    print(f\"  [{chunk.source}, chunk {chunk.index}] \\\"{preview}...\\\"\")\n",
+    "    print(f\"    Length: {len(chunk.text)} chars\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dfeceed",
+   "metadata": {},
+   "source": [
+    "## 4. Embedding — Generating Vectors\n",
+    "\n",
+    "Each chunk is encoded into a dense vector using `sentence-transformers`\n",
+    "(model: `all-MiniLM-L6-v2`, dimension: 384).  \n",
+    "This runs **locally** — no API key required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b5536b84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Projects\\ai_knowledge_assistant\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "BertModel LOAD REPORT from: sentence-transformers/all-MiniLM-L6-v2\n",
+      "Key                     | Status     |  | \n",
+      "------------------------+------------+--+-\n",
+      "embeddings.position_ids | UNEXPECTED |  | \n",
+      "\n",
+      "Notes:\n",
+      "- UNEXPECTED\t:can be ignored when loading from different task/architecture; not ok if you expect identical arch.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded 96 chunks\n",
+      "Vector dimension: 384\n",
+      "\n",
+      "Sample — [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\a.txt, chunk 0]\n",
+      "  Vector (first 10 values): [0.091, -0.0182, 0.0331, 0.098, -0.1009, 0.0054, 0.0088, -0.0374, -0.0747, -0.0006]\n"
+     ]
+    }
+   ],
+   "source": [
+    "builder = EmbeddingBuilder(config=config.DEFAULT_EMBEDDING)\n",
+    "embedded_chunks = builder.build_vectors(chunks)\n",
+    "\n",
+    "print(f\"Embedded {len(embedded_chunks)} chunks\")\n",
+    "print(f\"Vector dimension: {len(embedded_chunks[0].vector)}\")\n",
+    "print()\n",
+    "\n",
+    "# Preview the first vector\n",
+    "sample = embedded_chunks[0]\n",
+    "print(f\"Sample — [{sample.source}, chunk {sample.index}]\")\n",
+    "print(f\"  Vector (first 10 values): {[round(v, 4) for v in sample.vector[:10]]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a879d2b9",
+   "metadata": {},
+   "source": [
+    "## 5. Storage — Persisting Index and Vectors\n",
+    "\n",
+    "Chunks are saved to `index.json` and vectors to `vectors.json`.\n",
+    "These files are later loaded for retrieval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "00693ff8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved data_set\\output\\index.json   (59,021 bytes)\n",
+      "Saved data_set\\output\\vectors.json (1,128,440 bytes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "os.makedirs(os.path.dirname(config.INDEX_FILE), exist_ok=True)\n",
+    "\n",
+    "save_chunks(chunks, path=config.INDEX_FILE)\n",
+    "save_chunks_vectors(embedded_chunks, path=config.VECTORS_FILE)\n",
+    "\n",
+    "index_size = os.path.getsize(config.INDEX_FILE)\n",
+    "vectors_size = os.path.getsize(config.VECTORS_FILE)\n",
+    "\n",
+    "print(f\"Saved {config.INDEX_FILE}   ({index_size:,} bytes)\")\n",
+    "print(f\"Saved {config.VECTORS_FILE} ({vectors_size:,} bytes)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60b2574f",
+   "metadata": {},
+   "source": [
+    "## 6. Retrieval — Semantic Search\n",
+    "\n",
+    "The `Retriever` loads the vectors, builds an in-memory FAISS index,\n",
+    "encodes the question, and returns the most relevant chunks\n",
+    "ranked by **cosine similarity**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "19dedc40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Question: What role does Python play in machine learning and large systems?\n",
+      "Retrieved 4 context chunks:\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\ai_and_ml_overview.txt, chunk 0]\n",
+      "    \"Artificial intelligence is a broad field concerned with building intelligent systems. Machine learning is a subfield that focuses on learning patterns...\"\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\ai_and_ml_overview.txt, chunk 1]\n",
+      "    \"arning research. This is due to frameworks such as PyTorch and TensorFlow. Researchers use Python to experiment with models quickly.  In production AI...\"\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\python_systems.txt, chunk 0]\n",
+      "    \"Python is widely used in modern software systems. It is often chosen for backend services, automation, and scripting. One reason for its popularity is...\"\n",
+      "\n",
+      "  [c:\\Projects\\ai_knowledge_assistant\\data_set\\inputs\\dir2\\python_systems.txt, chunk 1]\n",
+      "    \" engineering pipelines. It is frequently used to process logs, transform datasets, and validate data. These pipelines often run in distributed environ...\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "retriever = Retriever(\n",
+    "    embedding_config=config.DEFAULT_EMBEDDING,\n",
+    "    vectors_path=config.VECTORS_FILE,\n",
+    ")\n",
+    "\n",
+    "DEMO_QUESTION = \"What role does Python play in machine learning and large systems?\"\n",
+    "\n",
+    "results = retriever.retrieve(DEMO_QUESTION, limit=5)\n",
+    "\n",
+    "print(f\"Question: {DEMO_QUESTION}\")\n",
+    "print(f\"Retrieved {len(results)} context chunks:\\n\")\n",
+    "for chunk in results:\n",
+    "    preview = chunk.text[:150].replace(\"\\n\", \" \")\n",
+    "    print(f\"  [{chunk.source}, chunk {chunk.index}]\")\n",
+    "    print(f\"    \\\"{preview}...\\\"\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ac049aa",
+   "metadata": {},
+   "source": [
+    "## 7. Grounding — Answerability Gate & Prompt\n",
+    "\n",
+    "Before calling the LLM, the **Answerability Gate** checks whether\n",
+    "the retrieved context is sufficient (≥ 800 total characters).  \n",
+    "If it passes, we build the grounded prompt with source citations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b796f56c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total context chars : 1,723\n",
+      "Min required        : 800\n",
+      "Answerability gate  : ✅ PASS\n",
+      "\n",
+      "=== Generated Prompt (first 600 chars) ===\n",
+      "You are an AI assistant answering questions based strictly on provided context.\n",
+      "\n",
+      "You must follow these rules:\n",
+      "1. Use ONLY the provided context.\n",
+      "2. Do NOT use prior knowledge.\n",
+      "3. For every factual statement, cite the source in this exact format: [Source: <filename>, chunk <index>]\n",
+      "4. If the answer cannot be found in the context, respond exactly: INSUFFICIENT_CONTEXT\n",
+      "\n",
+      "--- CONTEXT ---\n",
+      "\n",
+      "[Source: ai_and_ml_overview.txt, chunk 0]\n",
+      "Artificial intelligence is a broad field concerned with building intelligent systems.\n",
+      "Machine learning is a subfield that focuses on learning patterns from data.\n",
+      "\n",
+      "In machin\n",
+      "...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Answerability check\n",
+    "gate = AnswerabilityGate()\n",
+    "total_chars = sum(len(c.text) for c in results)\n",
+    "is_answerable = gate.should_answer(results)\n",
+    "\n",
+    "print(f\"Total context chars : {total_chars:,}\")\n",
+    "print(f\"Min required        : {config.MIN_TOTAL_CHARS}\")\n",
+    "print(f\"Answerability gate  : {'✅ PASS' if is_answerable else '❌ FAIL'}\")\n",
+    "print()\n",
+    "\n",
+    "# Build grounded prompt\n",
+    "prompt = build_prompt(DEMO_QUESTION, results)\n",
+    "print(\"=== Generated Prompt (first 600 chars) ===\")\n",
+    "print(prompt[:600])\n",
+    "print(\"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe1d15d6",
+   "metadata": {},
+   "source": [
+    "## 8. LLM Generation & Citation Validation\n",
+    "\n",
+    "> **Requires `OPENAI_API_KEY`** — set it in your environment before running.\n",
+    "\n",
+    "The prompt is sent to OpenAI. After generation, the **Output Validator**\n",
+    "ensures every `[Source: file, chunk N]` citation references a chunk\n",
+    "that was actually retrieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e26b2a0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== ANSWER ===\n",
+      "Python plays a significant role in machine learning by serving as the dominant language for research, largely due to frameworks such as PyTorch and TensorFlow. Researchers use Python to experiment with models quickly. In production AI systems, Python is often used in supporting components such as monitoring, scaling, and data validation [Source: ai_and_ml_overview.txt, chunk 1].\n",
+      "\n",
+      "In large systems, Python is commonly used to glue components together, integrating well with C++ modules and external services, making it suitable for orchestration layers. It is also popular in data engineering pipelines for processing logs, transforming datasets, and validating data. Even when performance-critical parts are written in other languages, Python often remains the control layer that coordinates execution, a design pattern common in cloud-based architectures [Source: python_systems.txt, chunk 0; Source: python_systems.txt, chunk 1].\n",
+      "\n",
+      "Citation validation: ❌ FAIL\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    print(\"⚠️  OPENAI_API_KEY not set — skipping LLM generation.\")\n",
+    "    print(\"Set the variable and re-run this cell to see the full demo.\")\n",
+    "else:\n",
+    "    llm = OpenAIClient()\n",
+    "    llm_config = LLMConfig(model=config.DEFAULT_LLM_MODEL)\n",
+    "\n",
+    "    answer = llm.generate(prompt, config=llm_config)\n",
+    "\n",
+    "    # Citation validation\n",
+    "    validator = OutputValidator()\n",
+    "    is_valid = validator.validate(answer=answer, contexts=results)\n",
+    "\n",
+    "    print(\"=== ANSWER ===\")\n",
+    "    print(answer)\n",
+    "    print()\n",
+    "    print(f\"Citation validation: {'✅ PASS' if is_valid else '❌ FAIL'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "550f3e68",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Pipeline Summary\n",
+    "\n",
+    "| Step | Module | What happened |\n",
+    "|------|--------|---------------|\n",
+    "| **Ingestion** | `ingest.read_files` | Discovered and read all `.txt`/`.md` files |\n",
+    "| **Chunking** | `normalize.get_chunks_from_files` | Split text into overlapping 500-char chunks |\n",
+    "| **Embedding** | `embedding.EmbeddingBuilder` | Encoded chunks into 384-dim vectors (local model) |\n",
+    "| **Storage** | `store.save_chunks` / `save_chunks_vectors` | Persisted index and vectors to JSON |\n",
+    "| **Retrieval** | `retrieve.Retriever` | Semantic search via FAISS (cosine similarity) |\n",
+    "| **Grounding** | `grounding.AnswerabilityGate` | Verified sufficient context before LLM call |\n",
+    "| **Generation** | `llm.OpenAIClient` | Generated answer via OpenAI with grounded prompt |\n",
+    "| **Validation** | `grounding.OutputValidator` | Verified all citations reference retrieved chunks |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.14.2)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ai_knowledge_assistant/config.py
+++ b/src/ai_knowledge_assistant/config.py
@@ -1,3 +1,12 @@
+"""
+Central configuration module for the AI Knowledge Assistant.
+
+Defines application-wide constants covering embedding models, LLM settings,
+retrieval/chunking parameters, grounding thresholds, and file-store paths.
+All tuneable values should be changed here rather than inline throughout the
+codebase.
+"""
+
 import os
 
 from ai_knowledge_assistant.embedding import EmbeddingConfig

--- a/src/ai_knowledge_assistant/embedding/builder.py
+++ b/src/ai_knowledge_assistant/embedding/builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 from .base import EmbeddedChunk, EmbeddingConfig
 

--- a/src/ai_knowledge_assistant/ingest/reader.py
+++ b/src/ai_knowledge_assistant/ingest/reader.py
@@ -1,3 +1,16 @@
+"""File ingestion utilities for reading text documents from disk.
+
+Provides two public helpers:
+- ``read_files`` – accepts a list of file/directory paths and returns a
+  mapping of absolute file path → raw text content for every supported file
+  that was found.
+- ``explore_files`` – walks paths recursively and returns the sorted list of
+  all discovered absolute file paths.
+
+Only file extensions listed in ``config.SUPPORTED_EXTENSIONS`` are read;
+unsupported files are silently skipped.
+"""
+
 # reader.py file
 
 import logging
@@ -10,6 +23,16 @@ logger = logging.getLogger(__name__)
 
 
 def read_files(paths: list[str]) -> dict[str, str]:
+    """Read all supported files found under the given paths.
+
+    Args:
+        paths: A list of file or directory paths to search. Directories are
+            walked recursively.
+
+    Returns:
+        A dict mapping each absolute file path to its text content.  Files
+        that cannot be read or whose extension is not supported are excluded.
+    """
     logger.debug(f"read_files({paths})")
     file_paths = explore_files(paths)
     logger.info(f"file_paths: [\n\t{'\n\t'.join(file_paths)}\n\t]")
@@ -24,6 +47,18 @@ def read_files(paths: list[str]) -> dict[str, str]:
 
 
 def explore_files(paths: list[str]) -> list[str]:
+    """Resolve a mixed list of files and directories to absolute file paths.
+
+    Each entry in *paths* is resolved to its absolute form.  Missing paths are
+    logged as errors and skipped.  Directories are walked recursively; all
+    files encountered (regardless of extension) are included in the result.
+
+    Args:
+        paths: A list of file or directory paths (relative or absolute).
+
+    Returns:
+        A sorted list of unique absolute file paths.
+    """
 
     file_paths: set[str] = set()
 
@@ -49,6 +84,19 @@ def explore_files(paths: list[str]) -> list[str]:
 
 
 def read_file(file_path: str) -> str | None:
+    """Read a single file and return its contents as a string.
+
+    Only files whose extension appears in ``config.SUPPORTED_EXTENSIONS`` are
+    read.  Any file that does not exist, is not a regular file, or has an
+    unsupported extension returns ``None``.
+
+    Args:
+        file_path: Absolute or relative path to the file.
+
+    Returns:
+        The file's text content, or ``None`` if the file could not or should
+        not be read.
+    """
 
     if not os.path.exists(file_path):
         logger.error(f"File {file_path} - Not exist")

--- a/src/ai_knowledge_assistant/normalize/chunker.py
+++ b/src/ai_knowledge_assistant/normalize/chunker.py
@@ -1,3 +1,13 @@
+"""Text chunking utilities for splitting documents into overlapping segments.
+
+This module provides:
+- ``get_chunks_from_files`` – batch-splits a dict of file contents into
+  :class:`~normalize.base.Chunk` objects.
+- ``split_into_chunks`` – splits a single document string into overlapping
+  fixed-size chunks using the ``CHUNK_SIZE`` and ``CHUNK_OVERLAP`` settings
+  defined in :mod:`config`.
+"""
+
 # src\ai_knowledge_assistant\normalize\chunker.py file
 import logging
 
@@ -9,6 +19,20 @@ logger = logging.getLogger(__name__)
 
 
 def get_chunks_from_files(text_by_file: dict[str, str]) -> list[Chunk]:
+    """Chunk all files in the provided mapping.
+
+    Iterates over each (filename, text) pair, delegates chunking to
+    :func:`split_into_chunks`, and concatenates the results into a single
+    flat list.
+
+    Args:
+        text_by_file: A dict mapping file names (or paths) to their raw text
+            content.
+
+    Returns:
+        A flat list of :class:`~normalize.base.Chunk` objects ordered by
+        file then by chunk index.
+    """
 
     results: list[Chunk] = []
     for file_name, text in text_by_file.items():

--- a/src/ai_knowledge_assistant/retrieve/retriever.py
+++ b/src/ai_knowledge_assistant/retrieve/retriever.py
@@ -3,9 +3,9 @@
 import logging
 
 from ai_knowledge_assistant.embedding import (
-    EmbeddingConfig,
     EmbeddedChunk,
     EmbeddingBuilder,
+    EmbeddingConfig,
 )
 from ai_knowledge_assistant.normalize import Chunk
 from ai_knowledge_assistant.store import FaissStore, ScoredChunk, load_chunks_vectors

--- a/src/ai_knowledge_assistant/store/base.py
+++ b/src/ai_knowledge_assistant/store/base.py
@@ -1,3 +1,13 @@
+"""Base types and shared persistence utilities for the store layer.
+
+Provides:
+- :func:`save_to_json` – serialize a list of dataclasses to a JSON file.
+- :func:`load_from_json` – deserialize a JSON file back into typed dataclass
+  instances.
+- :class:`ScoredChunk` – immutable dataclass representing a retrieved chunk
+  together with its similarity score.
+"""
+
 # ai_knowledge_assistant\store\base.py
 import json
 import logging
@@ -38,6 +48,16 @@ def load_from_json[T](path: str, cls: type[T], label: str = "items") -> list[T]:
 
 @dataclass(frozen=True)
 class ScoredChunk:
+    """A document chunk annotated with a retrieval similarity score.
+
+    Attributes:
+        source: The file name or path the chunk was extracted from.
+        index: Zero-based position of this chunk within its source document.
+        text: The raw text content of the chunk.
+        score: Cosine-similarity score (0-1) assigned by the vector store.
+        vector: Optional embedding vector; may be ``None`` when not needed.
+    """
+
     source: str
     index: int
     text: str

--- a/src/ai_knowledge_assistant/store/faiss_store.py
+++ b/src/ai_knowledge_assistant/store/faiss_store.py
@@ -1,3 +1,12 @@
+"""FAISS-backed in-memory vector store for nearest-neighbor similarity search.
+
+This module exposes :class:`FaissStore`, which wraps a FAISS
+``IndexFlatIP`` (inner-product / cosine similarity) index and stores the
+original :class:`~embedding.EmbeddedChunk` objects alongside the raw
+vectors so that results can be returned as rich :class:`~store.base.ScoredChunk`
+instances.
+"""
+
 # src\ai_knowledge_assistant\store\faiss_store.py file
 import json
 import logging
@@ -13,12 +22,36 @@ logger = logging.getLogger(__name__)
 
 
 class FaissStore:
+    """In-memory FAISS vector index with cosine-similarity search.
+
+    Vectors are L2-normalized before being added to the index so that
+    inner-product scores are equivalent to cosine similarity scores in the
+    range [0, 1].
+    """
+
     def __init__(self, dim: int):
+        """Initialise an empty index for vectors of the given dimensionality.
+
+        Args:
+            dim: The dimensionality of the embedding vectors that will be
+                stored (e.g. 384 for ``all-MiniLM-L6-v2``).
+        """
         self.dim = dim
         self.index = faiss.IndexFlatIP(dim)  # Inner Product (cosine-ready)
         self.items: list[EmbeddedChunk] = []
 
     def build(self, chunks: list[EmbeddedChunk]) -> None:
+        """Populate the index from a list of embedded chunks.
+
+        All previously indexed vectors are discarded when this method is
+        called.  Vectors are L2-normalized in-place before being added to
+        the FAISS index.
+
+        Args:
+            chunks: The embedded chunks whose vectors should be indexed.  An
+                empty list is accepted but results in a warning and leaves
+                the index empty.
+        """
         if not chunks:
             logger.warning(
                 "build() called with an empty chunk list. Index will remain empty."
@@ -33,6 +66,23 @@ class FaissStore:
     def search(
         self, query_vector: list[float], k: int = 5, threshold: float = 0.3
     ) -> list[ScoredChunk]:
+        """Return the top-*k* chunks most similar to the query vector.
+
+        The query vector is L2-normalized before querying so scores are
+        cosine-similarity values in [0, 1].  Only results whose score meets
+        or exceeds *threshold* are included.
+
+        Args:
+            query_vector: The embedding of the query, as a flat list of
+                floats.
+            k: Maximum number of results to return.  Defaults to 5.
+            threshold: Minimum cosine-similarity score a result must have to
+                be included in the output.  Defaults to 0.3.
+
+        Returns:
+            A list of :class:`~store.base.ScoredChunk` objects sorted by
+            descending similarity score (FAISS guarantees this ordering).
+        """
         results: list[ScoredChunk] = []
         q = np.array([query_vector]).astype("float32")
         faiss.normalize_L2(q)

--- a/src/ai_knowledge_assistant/store/faiss_store.py
+++ b/src/ai_knowledge_assistant/store/faiss_store.py
@@ -16,6 +16,7 @@ import faiss
 import numpy as np
 
 from ai_knowledge_assistant.embedding import EmbeddedChunk
+
 from .base import ScoredChunk
 
 logger = logging.getLogger(__name__)

--- a/src/ai_knowledge_assistant/store/json_store.py
+++ b/src/ai_knowledge_assistant/store/json_store.py
@@ -10,5 +10,6 @@ def save_chunks(chunks: list[Chunk], path: str) -> None:
 
 
 def load_chunks(path: str) -> list[Chunk]:
-    """Loads chunks from a JSON file and converts them back into Chunk dataclass instances."""
+    """Loads chunks from a JSON file and converts them back into Chunk dataclass
+    instances."""
     return load_from_json(path, Chunk, label="chunks")

--- a/src/ai_knowledge_assistant/store/vector_store.py
+++ b/src/ai_knowledge_assistant/store/vector_store.py
@@ -10,5 +10,6 @@ def save_chunks_vectors(chunks: list[EmbeddedChunk], path: str) -> None:
 
 
 def load_chunks_vectors(path: str) -> list[EmbeddedChunk]:
-    """Loads vector chunks from JSON and deserializes them into EmbeddedChunk instances."""
+    """Loads vector chunks from JSON and deserializes them into EmbeddedChunk
+    instances."""
     return load_from_json(path, EmbeddedChunk, label="vectors")


### PR DESCRIPTION
## Documentation & Productization

Completes the documentation milestone ([#15](https://github.com/DorLevi694/ai_knowledge_assistant/issues/15)) with all three sub-issues:

### Changes

- **Docstrings (#16)** — Added module and function docstrings to `config.py`, `reader.py`, `chunker.py`, `faiss_store.py`, and `store/base.py`
- **README (#17)** — Professional README with installation, usage, CLI reference, architecture overview, and grounding explanation
- **RAG Demo (#18)** — End-to-end Jupyter notebook (`demo.ipynb`) demonstrating the full pipeline: ingestion → chunking → embedding → storage → retrieval → grounding → LLM generation → citation validation

### Demo Notebook Highlights

- Sections 1–7 run **locally** (no API key needed) — covers ingestion through retrieval
- Section 8 requires `OPENAI_API_KEY` and gracefully skips if not set
- Includes Mermaid pipeline diagram and summary table

Closes #15, closes #16, closes #17, closes #18