### PR TITLE
fix: use sys.executable in integration test subprocess calls

### DIFF
--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 
@@ -13,7 +14,7 @@ def test_full_workflow():
     # Step 1: Indexing
     print("\nRunning Step 1: Indexing...")
     index_cmd = [
-        "python",
+        sys.executable,
         "-m",
         "ai_knowledge_assistant.cli",
         "index",
@@ -32,7 +33,7 @@ def test_full_workflow():
     # Step 2: Asking
     print("\nRunning Step 2: Asking...")
     ask_cmd = [
-        "python",
+        sys.executable,
         "-m",
         "ai_knowledge_assistant.cli",
         "ask",


### PR DESCRIPTION
Fixes the integration test by replacing hardcoded python with sys.executable so the subprocess always uses the same Python interpreter as pytest (i.e. the venv). Also installs the package in editable mode to ensure the module is importable.