### PR TITLE
fix: test assertions + CI ruff upgrade

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,6 +14,13 @@ jobs:
           python-version: "3.14"
 
       - name: Run Ruff
-        uses: astral-sh/ruff-action@v1
+        uses: astral-sh/ruff-action@v4.0.0
         with:
           version: "latest"
+          args: "check"
+
+      - name: Run Ruff format check
+        uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "latest"
+          args: "format --check"

--- a/tests/unit/test_chunker.py
+++ b/tests/unit/test_chunker.py
@@ -19,6 +19,7 @@ def test_split_into_chunks_basic(monkeypatch):
     assert chunks[0].index == 0
     assert chunks[1].index == 1
     assert chunks[0].source == "test.txt"
+    assert chunks[1].source == "test.txt"
 
 
 def test_split_into_chunks_small_text(monkeypatch):
@@ -29,3 +30,5 @@ def test_split_into_chunks_small_text(monkeypatch):
     chunks = split_into_chunks("small.txt", text)
     assert len(chunks) == 1
     assert chunks[0].text == "small"
+    assert chunks[0].source == "small.txt"
+    assert chunks[0].index == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -32,3 +32,5 @@ def test_cmd_index_creates_output_dir(
 
     assert result == 0
     assert os.path.isdir(str(tmp_path / "sub"))
+    mock_save.assert_called_once()
+    mock_save_vec.assert_called_once()

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -1,3 +1,4 @@
+from ai_knowledge_assistant.config import PROMPT_SYSTEM_INSTRUCTIONS
 from ai_knowledge_assistant.normalize.chunker import Chunk
 from ai_knowledge_assistant.rag.prompt_builder import build_prompt
 
@@ -17,6 +18,7 @@ def test_build_prompt_with_context():
     assert "[Source: recipe.txt, chunk 0]" in prompt
     assert "[Source: recipe.txt, chunk 1]" in prompt
     assert "--- CONTEXT ---" in prompt
+    assert PROMPT_SYSTEM_INSTRUCTIONS in prompt
 
 
 def test_build_prompt_no_context():


### PR DESCRIPTION
## Summary

Two independent fixes committed on this branch.

### 1. CI — Upgrade ruff GitHub Action

**Problem:** The workflow used \stral-sh/ruff-action@v1\ (Oct 2024). That version did not properly respect the \ersion: 'latest'\ input and installed an old ruff binary that did not support \	arget-version = 'py314'\ in \pyproject.toml\, causing the Ruff CI job to fail.

**Fix:**
- Upgraded to \stral-sh/ruff-action@v4.0.0\ (current stable, Node 24)
- Added explicit \uff format --check\ step

### 2. Unit tests — Missing assertions

| Test | Missing assertion added |
|------|------------------------|
| \	est_split_into_chunks_basic\ | \chunks[1].source\ |
| \	est_split_into_chunks_small_text\ | \source\ and \index\ fields |
| \	est_cmd_index_creates_output_dir\ | \mock_save\ and \mock_save_vec\ called |
| \	est_build_prompt_with_context\ | \PROMPT_SYSTEM_INSTRUCTIONS\ in prompt |

All 11 tests pass.