### PR TITLE
fix: skip RAG integration tests when OPENAI_API_KEY is missing

### DIFF
--- a/tests/integration/test_rag_questions.py
+++ b/tests/integration/test_rag_questions.py
@@ -7,10 +7,16 @@ Positive questions  — the answer EXISTS in orlit_company.txt  → expect exit 
 Negative questions  — the answer does NOT exist anywhere       → expect exit 2
 """
 
+import os
 import subprocess
 import sys
 
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set; these tests call the real OpenAI API",
+)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
## Summary
- Addresses the bot review comment on #37: RAG integration tests in `tests/integration/test_rag_questions.py` call the real CLI/OpenAI API and were failing (not skipping) when `OPENAI_API_KEY` is absent, masking real regressions with credential errors.
- Adds a module-level `pytestmark` skip so all tests (and the `build_index` fixture) are skipped, not failed, when the key isn't set.

## Test plan
- [x] Run `pytest tests/integration/test_rag_questions.py` with `OPENAI_API_KEY` unset — confirm tests report as skipped.
- [x] Run with `OPENAI_API_KEY` set — confirm tests execute as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)